### PR TITLE
Calculate next purchase date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -88,13 +88,20 @@ export async function updateItem(listId, key, checkedState) {
 			: doc.data().dateLastPurchased;
 
 		const currentDate = new Date();
-		const previousEstimate = doc.data().daysTillNextPurchase;
+
 		const dateCreated = new Date(doc.data().dateCreated.toDate());
 
 		const dateLastPurchased =
 			doc.data().dateLastPurchased === null
 				? dateCreated
 				: new Date(doc.data().dateLastPurchased.toDate());
+
+		const dateNextPurchased = new Date(doc.data().dateNextPurchased.toDate());
+
+		const previousEstimate = getDaysBetweenDates(
+			dateNextPurchased,
+			dateLastPurchased,
+		);
 
 		const daysSinceLastPurchase = getDaysBetweenDates(
 			currentDate,
@@ -112,7 +119,6 @@ export async function updateItem(listId, key, checkedState) {
 			dateLastPurchased: newDateLastPurchased,
 			checked: checkedState,
 			dateNextPurchased: getFutureDate(daysTilNextPurchase),
-			daysTilNextPurchase: daysTilNextPurchase,
 		});
 	});
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -87,32 +87,19 @@ export async function updateItem(listId, key, checkedState) {
 			? new Date()
 			: doc.data().dateLastPurchased;
 
-		updateDoc(docRef, {
-			totalPurchases: newTotalPurchases,
-			dateLastPurchased: newDateLastPurchased,
-			checked: checkedState,
-		});
-
 		const currentDate = new Date();
-		const updatedDateNextPurchased = new Date(
-			doc.data().dateNextPurchased.toDate(),
+		const previousEstimate = doc.data().daysTillNextPurchase;
+		const dateCreated = new Date(doc.data().dateCreated.toDate());
+
+		const dateLastPurchased =
+			doc.data().dateLastPurchased === null
+				? dateCreated
+				: new Date(doc.data().dateLastPurchased.toDate());
+
+		const daysSinceLastPurchase = getDaysBetweenDates(
+			currentDate,
+			dateLastPurchased,
 		);
-		const updatedDateCreated = new Date(doc.data().dateCreated.toDate());
-		const formattedDateLastPurchased = new Date(newDateLastPurchased);
-
-		// gets last estimated interval
-		const previousEstimate =
-			updatedDateNextPurchased === null
-				? getDaysBetweenDates(updatedDateNextPurchased, updatedDateCreated)
-				: getDaysBetweenDates(
-						updatedDateNextPurchased,
-						formattedDateLastPurchased,
-				  );
-
-		const daysSinceLastPurchase =
-			updatedDateNextPurchased === null
-				? getDaysBetweenDates(currentDate, updatedDateCreated)
-				: getDaysBetweenDates(currentDate, formattedDateLastPurchased);
 
 		const daysTilNextPurchase = calculateEstimate(
 			previousEstimate,
@@ -121,7 +108,11 @@ export async function updateItem(listId, key, checkedState) {
 		);
 
 		updateDoc(docRef, {
+			totalPurchases: newTotalPurchases,
+			dateLastPurchased: newDateLastPurchased,
+			checked: checkedState,
 			dateNextPurchased: getFutureDate(daysTilNextPurchase),
+			daysTilNextPurchase: daysTilNextPurchase,
 		});
 	});
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,7 +7,7 @@ import {
 	getDoc,
 } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * Subscribe to changes on a specific list in the Firestore database (listId), and run a callback (handleSuccess) every time a change happens.
@@ -85,11 +85,23 @@ export async function updateItem(listId, key, checkedState) {
 		const newDateLastPurchased = checkedState
 			? new Date()
 			: doc.data().dateLastPurchased;
+
 		updateDoc(docRef, {
 			totalPurchases: newTotalPurchases,
 			dateLastPurchased: newDateLastPurchased,
 			checked: checkedState,
 		});
+
+		const updatedDateNextPurchased = doc.data().dateNextPurchased.toDate();
+		const updatedDateCreated = doc.data().dateCreated.toDate();
+
+		// gets last estimated interval based
+		const estimatedInterval =
+			updatedDateNextPurchased === null
+				? getDaysBetweenDates(updatedDateNextPurchased, updatedDateCreated)
+				: getDaysBetweenDates(updatedDateNextPurchased, newDateLastPurchased);
+
+		console.log(estimatedInterval);
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -94,19 +94,25 @@ export async function updateItem(listId, key, checkedState) {
 		});
 
 		const currentDate = new Date();
-		const updatedDateNextPurchased = doc.data().dateNextPurchased.toDate();
-		const updatedDateCreated = doc.data().dateCreated.toDate();
+		const updatedDateNextPurchased = new Date(
+			doc.data().dateNextPurchased.toDate(),
+		);
+		const updatedDateCreated = new Date(doc.data().dateCreated.toDate());
+		const formattedDateLastPurchased = new Date(newDateLastPurchased);
 
 		// gets last estimated interval
 		const previousEstimate =
 			updatedDateNextPurchased === null
 				? getDaysBetweenDates(updatedDateNextPurchased, updatedDateCreated)
-				: getDaysBetweenDates(updatedDateNextPurchased, newDateLastPurchased);
+				: getDaysBetweenDates(
+						updatedDateNextPurchased,
+						formattedDateLastPurchased,
+				  );
 
 		const daysSinceLastPurchase =
 			updatedDateNextPurchased === null
 				? getDaysBetweenDates(currentDate, updatedDateCreated)
-				: getDaysBetweenDates(currentDate, newDateLastPurchased);
+				: getDaysBetweenDates(currentDate, formattedDateLastPurchased);
 
 		const daysTilNextPurchase = calculateEstimate(
 			previousEstimate,
@@ -114,7 +120,6 @@ export async function updateItem(listId, key, checkedState) {
 			newTotalPurchases,
 		);
 
-		console.log(daysTilNextPurchase);
 		updateDoc(docRef, {
 			dateNextPurchased: getFutureDate(daysTilNextPurchase),
 		});

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,7 +12,7 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(newDate, oldDate) {
-	const timeDifference = newDate.getTime() - oldDate.getTime();
+	const timeDifference = newDate - oldDate;
 
 	const differenceInDays = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
 	return differenceInDays;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,15 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(newDate, oldDate) {
+	console.log(newDate);
+	console.log(oldDate);
+	const newDateToMilliSeconds = newDate.getTime();
+	const oldDateToMilliSeconds = oldDate.getTime();
+
+	const timeDifference = newDateToMilliSeconds - oldDateToMilliSeconds;
+
+	const daysBetween = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
+	return daysBetween;
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -12,13 +12,8 @@ export function getFutureDate(offset) {
 }
 
 export function getDaysBetweenDates(newDate, oldDate) {
-	console.log(newDate);
-	console.log(oldDate);
-	const newDateToMilliSeconds = newDate.getTime();
-	const oldDateToMilliSeconds = oldDate.getTime();
+	const timeDifference = newDate.getTime() - oldDate.getTime();
 
-	const timeDifference = newDateToMilliSeconds - oldDateToMilliSeconds;
-
-	const daysBetween = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
-	return daysBetween;
+	const differenceInDays = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
+	return differenceInDays;
 }


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

This PR adds a new feature that allows the application to estimate the number of days that it takes for a user to need to buy an item again. For each time that the user purchases an item, the item's dateNextPurchased property is calculated and updated to the database.

## Related Issue
Closes #10 
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance criteria
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |


## Updates

### Before

Each item's dateNextPurchased property is not updated whenever they purchase (click on) an item. The property is kept constant from when the item was first created and added to the shopping list. 

<!-- If UI feature, take provide screenshots -->

### After

Each item's dateNextPurchased property is updated with the value returned by calculateEstimate, which takes in the following variables: previousEstimate, daysSinceLastPurchase, and totalPurchase.

<!-- If UI feature, take provide screenshots -->

